### PR TITLE
Hisham new feature

### DIFF
--- a/project/.gitignore
+++ b/project/.gitignore
@@ -14,3 +14,5 @@ workbench.xmi
 .project
 .settings/
 .vscode/
+/.idea/
+/project.iml

--- a/project/src/main/java/ca/yorku/eecs/App.java
+++ b/project/src/main/java/ca/yorku/eecs/App.java
@@ -7,7 +7,6 @@ import com.sun.net.httpserver.HttpServer;
 public class App 
 {
     static int PORT = 8080;
-
     public static void main(String[] args) throws IOException
     {
         HttpServer server = HttpServer.create(new InetSocketAddress("0.0.0.0", PORT), 0);

--- a/project/src/main/java/ca/yorku/eecs/App.java
+++ b/project/src/main/java/ca/yorku/eecs/App.java
@@ -7,6 +7,7 @@ import com.sun.net.httpserver.HttpServer;
 public class App 
 {
     static int PORT = 8080;
+
     public static void main(String[] args) throws IOException
     {
         HttpServer server = HttpServer.create(new InetSocketAddress("0.0.0.0", PORT), 0);

--- a/project/src/main/java/ca/yorku/eecs/DBManager.java
+++ b/project/src/main/java/ca/yorku/eecs/DBManager.java
@@ -3,14 +3,7 @@ package ca.yorku.eecs;
 import org.neo4j.driver.v1.*;
 import org.neo4j.driver.v1.Record;
 
-import java.util.ArrayList;//Newly added import
-import java.util.HashMap;
-import java.util.HashSet;//Newly added import
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;//Newly added import
-import java.util.Set;//Newly added import
+import java.util.*;
 
 import static org.neo4j.driver.v1.Config.build;
 

--- a/project/src/main/java/ca/yorku/eecs/DBManager.java
+++ b/project/src/main/java/ca/yorku/eecs/DBManager.java
@@ -3,7 +3,6 @@ package ca.yorku.eecs;
 import org.neo4j.driver.v1.*;
 import org.neo4j.driver.v1.Record;
 
-import java.io.Console;
 import java.util.ArrayList;//Newly added import
 import java.util.HashMap;
 import java.util.HashSet;//Newly added import

--- a/project/src/main/java/ca/yorku/eecs/Utils.java
+++ b/project/src/main/java/ca/yorku/eecs/Utils.java
@@ -82,5 +82,33 @@ class Utils {
         return null;
     }
 
+    /*
+    determining if the input string a valid rating number between 1 and 5 inclusive
+    3 possible cases
+    1. input string is null. Return -1 to indicate this case
+    2. input string is not a valid integer or is not between 1 and 5 inclusive, in this case return 0.
+    3. input string is a valid integer between 1 and 5 inclusive, in this case, we want the API controller to continue
+       with the request. Return 1 to indicate this case
+     */
+    public static int isNumeric(String str) {
+        //case 1
+        if (str == null) {
+            return -1;
+        }
+        int d;
+        //case 2
+        //try catch block to avoid exception when parsing string to int
+        try {
+            d = Integer.parseInt(str);
+        } catch (NumberFormatException nfe) {
+            return 0;
+        }
+        //checking for range validity
+        if (d < 1 || d > 5) {
+            return 0;
+        }
+        //case 3
+        return 1;
+    }
 
 }


### PR DESCRIPTION
Logic and endpoint for the new feature. The addMovie endpoint can now take an optional 3rd parameter of "rating" within its JSON which is an integer value from 1 to 5 inclusive. The rating value must be provided as a string, the reasoning for this is explained in the code comments. Rating values are stored as integers within nodes. The new GET endpoint getMoviesByRating takes in a single parameter of "rating" and returns a list of movie titles that have a rating equal to the one provided. Rating must also be provided as a string in this case. 